### PR TITLE
Improve ceagle configurability

### DIFF
--- a/ceagle/templates/layout.html
+++ b/ceagle/templates/layout.html
@@ -9,7 +9,7 @@
         <meta name="description" content="">
         <meta name="author" content="">
         <link rel="icon" href="{{ url_for('static', filename='pics/favicon.ico') }}" type="image/x-icon" />
-        <title> Cloud Eagle - {{ title }} </title>
+        <title> {{ global_conf["portal_name"] }} - {{ title }} </title>
 
         <link href="{{ url_for('static', filename='css/bootstrap.css') }}" rel="stylesheet">
         <link href="{{ url_for('static', filename='css/main.css') }}" rel="stylesheet">
@@ -29,7 +29,7 @@
             <div class="navbar-header">
                 <a href="#">
                     <img src="{{ url_for('static', filename='pics/logo.png') }}" height="40px" />
-                    <span>Cloud Eagle</span>
+                    <span>{{ global_conf["portal_name"] }}</span>
                 </a>
             </div>
         </nav>

--- a/etc/README.rst
+++ b/etc/README.rst
@@ -1,0 +1,30 @@
+Ceagle Portal Configuration
+===========================
+
+Placement
+---------
+
+config.json should be placed to /etc/ceagle/config.json
+
+
+Configuration File Description
+------------------------------
+
+Configuration file is plain json document with 3 top level keys:
+
+* flask - Flask configuration arguments with Host and Port options added.
+* global - All global settings (e.g. cloud portal name)
+* cloud_status - cloud_status pages configuration
+
+
+Configuration Of cloud_status In Nuts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* enabled - If True initialize /cloud_status/ API and "Cloud status" menu
+* enabled_dashboards - initializes sub API /cloud_status/availability and /cloud_status/health with sub menus
+* regions - list of regions that should be displayed
+** region - displayed name of region
+** health - dict with 2 items connection URL to Elastic Search &  index from what to query health data production by
+            https://github.com/ceagle/health
+** availability - dict with single argument "graphite" that is used to specify connection string to graphite that stores metrics.
+

--- a/etc/config.json
+++ b/etc/config.json
@@ -1,0 +1,37 @@
+{
+    "flask": {
+        "PORT": 5000,
+        "HOST": "0.0.0.0"
+    },
+
+    "global": {
+        "portal_name": "Cloud Eagle"
+    },
+
+    "cloud_status": {
+        "enabled":  true,
+        "enabled_dashboards": ["availability", "health"],
+        "regions": [
+            {
+                "region": "west-1.hooli.net",
+                "health": {
+                    "elastic": "<elastic_connection_string>",
+                    "elastic_index": "<index_with_data_in_required_format>"
+                },
+                "availability": {
+                    "graphite": "<graphite_connection_string>"
+                }
+            },
+            {
+                "region": "west-2.hooli.net",
+                "health": {
+                    "elastic": "<elastic_connection_string>",
+                    "elastic_index": "<index_with_data_in_required_format>"
+                },
+                "availability": {
+                    "graphite": "<graphite_connection_string>"
+                }
+            }
+        ]
+    }
+}

--- a/tests/unit/test.py
+++ b/tests/unit/test.py
@@ -25,5 +25,6 @@ class TestCase(testtools.TestCase):
         super(TestCase, self).setUp()
         self.addCleanup(mock.patch.stopall)
 
+        main.load_config()
         main.app.config["TESTING"] = True
         self.app = main.app.test_client()


### PR DESCRIPTION
- Automatically try to fetch config in json format from "/etc/ceagle/config.json"
- Allow to pass path to config file via CEAGLE_CONF env variable
- Add readme file that describes all config options
- Allow to specify name of portal
