### PR TITLE
D3 Line charts displays properly None values

### DIFF
--- a/ceagle/static/js/angular-d3.js
+++ b/ceagle/static/js/angular-d3.js
@@ -92,7 +92,8 @@ var line_chart = function(svg, title){
 
         var line = d3.line()
           .x(function(d) { return x(parse_date(d[0])); })
-          .y(function(d) { return y(d[1]); });
+          .y(function(d) { return y(d[1]); })
+          .defined(function(d) { return d[1] != null; })
 
         path.datum(data).transition().attr("d", line);
     }


### PR DESCRIPTION
None values are just skipped on chart (no line).
