### PR TITLE
Fix api get_client() function

### DIFF
--- a/ceagle/api/client.py
+++ b/ceagle/api/client.py
@@ -58,7 +58,7 @@ def get_client(service_name):
     :param service_name: str name of microservice
     :returns: Client
     """
-    endpoint = config.get_config().get(service_name)
+    endpoint = config.get_config().get("services", {}).get(service_name)
     if endpoint:
         return Client(name=service_name, endpoint=endpoint)
     return None

--- a/tests/unit/api/test_client.py
+++ b/tests/unit/api/test_client.py
@@ -78,14 +78,14 @@ class ModuleTestCase(test.TestCase):
     @mock.patch("ceagle.api.client.config")
     def test_get_config(self, mock_config):
         self.assertRaises(TypeError, client.get_client)
-        mock_config.get_config.return_value = {"bar": {}}
+        mock_config.get_config.return_value = {"services": {"bar": {}}}
         self.assertIsNone(client.get_client("foo"))
-        mock_config.get_config.return_value = {"foo": ""}
+        mock_config.get_config.return_value = {"services": {"foo": ""}}
         self.assertIsNone(client.get_client("foo"))
 
-        cfg = {"foo": "http://foo_ep"}
+        cfg = {"services": {"foo": "http://foo_ep"}}
         mock_config.get_config.return_value = cfg
         ct = client.get_client("foo")
         self.assertIsInstance(ct, client.Client)
         self.assertEqual("foo", ct.name)
-        self.assertEqual(cfg["foo"], ct.endpoint)
+        self.assertEqual(cfg["services"]["foo"], ct.endpoint)


### PR DESCRIPTION
It should look for service configuration in "services" subdict
not root dict