### PR TITLE
Refactor API tests setUp in a separate class

### DIFF
--- a/tests/unit/api/v1/base.py
+++ b/tests/unit/api/v1/base.py
@@ -1,0 +1,29 @@
+# Copyright 2016: Mirantis Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from ceagle.api_fake_data import base as fake_api_base
+from tests.unit import test
+
+
+class ApiTestCase(test.TestCase):
+
+    def setUp(self):
+        super(ApiTestCase, self).setUp()
+        self.old_USE_FAKE_DATA = fake_api_base.USE_FAKE_DATA
+        fake_api_base.USE_FAKE_DATA = False
+
+    def tearDown(self):
+        fake_api_base.USE_FAKE_DATA = self.old_USE_FAKE_DATA
+        super(ApiTestCase, self).tearDown()

--- a/tests/unit/api/v1/test_status.py
+++ b/tests/unit/api/v1/test_status.py
@@ -15,11 +15,11 @@
 
 import mock
 
-from ceagle.api_fake_data import base as fake_api_base
+from tests.unit.api.v1 import base as base_api
 from tests.unit import test
 
 
-class ApiTestCase(test.TestCase):
+class FakeApiTestCase(test.TestCase):
 
     def test_api_response_code(self):
         region = "north-2.piedpiper.net"
@@ -44,7 +44,7 @@ class ApiTestCase(test.TestCase):
 
 
 @mock.patch("ceagle.config.get_config")
-class HealthApiTestCase(test.TestCase):
+class HealthApiTestCase(base_api.ApiTestCase):
 
     def setUp(self):
         super(HealthApiTestCase, self).setUp()
@@ -53,13 +53,6 @@ class HealthApiTestCase(test.TestCase):
                 "health": "http://dummy.example.org/api/health"
             }
         }
-
-        self.old_USE_FAKE_DATA = fake_api_base.USE_FAKE_DATA
-        fake_api_base.USE_FAKE_DATA = False
-
-    def tearDown(self):
-        fake_api_base.USE_FAKE_DATA = self.old_USE_FAKE_DATA
-        super(HealthApiTestCase, self).tearDown()
 
     @mock.patch("ceagle.api.client.Client")
     def test_status_health_api(self, mock_client, mock_get_config):
@@ -93,20 +86,14 @@ class HealthApiTestCase(test.TestCase):
         self.assertEqual({"error": "No health endpoint configured"}, resp)
 
 
-class AvailabilityApiTestCase(test.TestCase):
+@mock.patch("ceagle.config.get_config")
+@mock.patch("ceagle.api.client.Client")
+class AvailabilityApiTestCase(base_api.ApiTestCase):
 
     def setUp(self):
         super(AvailabilityApiTestCase, self).setUp()
         self.config = {"services": {"availability": "foo_endpoint"}}
-        self.saved_use_fake_api = fake_api_base.USE_FAKE_DATA
-        fake_api_base.USE_FAKE_DATA = False
 
-    def tearDown(self):
-        fake_api_base.USE_FAKE_DATA = self.saved_use_fake_api
-        super(AvailabilityApiTestCase, self).tearDown()
-
-    @mock.patch("ceagle.config.get_config")
-    @mock.patch("ceagle.api.client.Client")
     def test_get_status_availability(self, mock_client, mock_config):
         uri = "/api/v1/status/availability/day"
 
@@ -124,8 +111,6 @@ class AvailabilityApiTestCase(test.TestCase):
         self.assertEqual({"data": "nice"}, resp)
         mock_get.assert_called_once_with("/api/v1/availability/day")
 
-    @mock.patch("ceagle.config.get_config")
-    @mock.patch("ceagle.api.client.Client")
     def test_get_region_status_availability(self, mock_client, mock_config):
         uri = "/api/v1/region/foo_region/status/availability/day"
 


### PR DESCRIPTION
* Introduces a base class ApiTestCase for api test cases
* Renames ApiTestCase into FakeApiTestCase, as it actually tests fake
api