### PR TITLE
Allow running abao from tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# abao tests run gunicorn in tox, this file is used to track it's pid and kill after run
+.gunicorn.pid

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - TOXENV=py27
   - TOXENV=py33
   - TOXENV=py34
+  - TOXENV=abao
 
 script:
   - tox

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -13,3 +13,5 @@ ddt>=1.0.1
 mock>=2.0
 
 testtools>=1.4.0
+
+nodeenv>=0.9.4 # BSD License  # BSD

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,15 @@ basepython = python3.4
 [testenv:py35]
 basepython = python3.5
 
+[testenv:abao]
+deps = -r{toxinidir}/test-requirements.txt
+passenv = *
+commands = nodeenv -p
+           npm install --save --save-dev -g abao@0.5.0
+           gunicorn -w 1 -b 0.0.0.0:5000 ceagle.main:app -D -p .gunicorn.pid
+           abao raml/api.raml --server http://127.0.0.1:5000 --hookfiles raml/abao_hooks.js
+           sh -c \'kill -9 `cat .gunicorn.pid`\'
+
 [testenv:venv]
 commands = {posargs}
 


### PR DESCRIPTION
Simply run tox -e abao to test raml files against fake api.