### PR TITLE
Fake mode should be turned on by default

### DIFF
--- a/ceagle/config.py
+++ b/ceagle/config.py
@@ -16,7 +16,7 @@
 DEFAULT_CONF_PATH = "/etc/ceagle/config.yaml"
 
 DEFAULT = {
-    "use_fake_api_data": False,
+    "use_fake_api_data": True,
     "services": {},
 }
 


### PR DESCRIPTION
This simplifies a lot running demo mode:
- Removes requirement to create config file & enable fake mode 
- Removes need to pass config to docker container